### PR TITLE
Add session-review skill for knowledge capture

### DIFF
--- a/.claude/skills/session-review/SKILL.md
+++ b/.claude/skills/session-review/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: session-review
+description: Review session for AGENTS.md additions and skill opportunities
+---
+
+# Session Review for Knowledge Capture
+
+Review this session to identify high-value learnings worth persisting. Focus on two outputs:
+
+## 1. Project Instructions Updates
+
+Scan the session for insights that would help future Claude sessions in this project. Only add items that are **genuinely high-value** - things that:
+- Took significant effort to discover
+- Would save time in future sessions
+- Are non-obvious from the codebase alone
+- Are project-specific patterns or gotchas
+
+Examples of what to add:
+- Build/test commands that aren't documented
+- Critical file locations or module relationships
+- Workflow requirements or constraints
+- Common errors and their solutions
+- Naming conventions or patterns
+
+If you find something worth adding, edit the project's instructions file directly (`AGENTS.md` or `CLAUDE.md`, whichever the project uses). Keep entries concise and actionable.
+
+## 2. Skill Opportunities
+
+Consider whether any task from this session should become a reusable skill. A skill is worth creating if:
+- The task required multiple steps that could be templated
+- The user is likely to need this workflow again
+- The task required specific domain knowledge
+
+If you identify a skill opportunity, either:
+- Create it in `~/.claude/skills/<skill-name>/SKILL.md` (for cross-project skills)
+- Create it in `.claude/skills/<skill-name>/SKILL.md` (for project-specific skills)
+
+## Output
+
+Summarize what you found:
+1. What (if anything) was added to project instructions
+2. What (if anything) was created as a skill
+3. Any observations that don't fit neatly into either category but are worth noting
+
+If nothing meets the bar for documentation, say so - don't force additions.

--- a/.claude/skills/session-review/SKILL.md
+++ b/.claude/skills/session-review/SKILL.md
@@ -9,7 +9,7 @@ Review this session to identify high-value learnings worth persisting. Focus on 
 
 ## 1. Project Instructions Updates
 
-Scan the session for insights that would help future Claude sessions in this project. Only add items that are **genuinely high-value** - things that:
+Scan the session and commits on this branch for insights that would help future Claude sessions in this project. Only add items that are **genuinely high-value** - things that:
 - Took significant effort to discover
 - Would save time in future sessions
 - Are non-obvious from the codebase alone


### PR DESCRIPTION
# Pull Request Summary 🚀

## What does this PR do? 📝

Adds a new `session-review` skill that helps Claude review coding sessions to identify learnings worth persisting to project documentation.

## Why is this change needed? 🤔

When working with Claude Code, valuable insights often emerge during sessions (build commands, gotchas, workflow patterns) that would benefit future sessions. This skill provides a structured way to capture that knowledge before it's lost.

## How was this implemented? 🛠️

- Added `.claude/skills/session-review/SKILL.md` following the standard skill structure
- Skill prompts Claude to scan the session for:
  1. Project instruction updates (AGENTS.md or CLAUDE.md)
  2. Opportunities to create reusable skills

## How to test or reproduce? 🧪

1. Open a Claude Code session in any project
2. Do some work that involves learning something non-obvious
3. Run `/session-review`
4. Verify Claude reviews the session and provides actionable output

## Checklist ✅

- [x] I have run and tested my changes locally
- [x] I have limited this PR to less than 1000 lines of code change (if not, explain why)
- [ ] I have updated/added tests to cover my changes (if applicable)
- [ ] I have updated/added requirements to cover my changes (if applicable)
- [ ] I have run linting and formatting on any code changes (if applicable)
- [ ] I have updated the documentation (README, etc.) accordingly

🤖 Generated with [Claude Code](https://claude.com/claude-code)